### PR TITLE
добавлены основные DTO и контроллеры

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,11 @@
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>2.5.0</version>
+    </dependency>
+        <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>

--- a/src/main/java/ru/skypro/homework/config/WebSecurityConfig.java
+++ b/src/main/java/ru/skypro/homework/config/WebSecurityConfig.java
@@ -9,7 +9,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
-import ru.skypro.homework.dto.Role;
+import ru.skypro.homework.dto.auth.Role;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 

--- a/src/main/java/ru/skypro/homework/controller/ad/AdController.java
+++ b/src/main/java/ru/skypro/homework/controller/ad/AdController.java
@@ -1,0 +1,63 @@
+package ru.skypro.homework.controller.ad;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import ru.skypro.homework.dto.ad.Ad;
+import ru.skypro.homework.dto.ad.Ads;
+import ru.skypro.homework.dto.ad.CreateOrUpdateAd;
+import ru.skypro.homework.dto.ad.ExtendedAd;
+
+import javax.annotation.PostConstruct;
+import java.util.Collections;
+
+@Slf4j
+@RestController
+@RequestMapping("/ads")
+@RequiredArgsConstructor
+@Tag(name = "Объявления")
+public class AdController {
+
+    // Временная заглушка вместо реального сервиса
+    @PostConstruct
+    private void init() {
+        log.warn("Используются заглушки вместо реального AdService!");
+    }
+
+    @GetMapping
+    @Operation(summary = "Получение всех объявлений")
+    public Ads getAllAds() {
+        // Заглушка: возвращаем пустой список объявлений
+        Ads stub = new Ads();
+        stub.setCount(0);
+        stub.setResults(Collections.emptyList());
+        return stub;
+    }
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "Добавление объявления")
+    public Ad addAd(
+            @RequestPart CreateOrUpdateAd properties,
+            @RequestPart MultipartFile image
+    ) {
+        // Заглушка: возвращаем тестовое объявление
+        Ad stub = new Ad();
+        stub.setPk(1);
+        stub.setTitle(properties.getTitle());
+        stub.setPrice(properties.getPrice());
+        stub.setImage("http://example.com/stub-image.jpg");
+        return stub;
+    }
+
+    @GetMapping("/{id}")
+    public ExtendedAd getAd(@PathVariable Integer id) {
+        ExtendedAd stub = new ExtendedAd();
+        stub.setPk(id);
+        stub.setTitle("Тестовое объявление");
+        return stub;
+    }
+}

--- a/src/main/java/ru/skypro/homework/controller/auth/AuthController.java
+++ b/src/main/java/ru/skypro/homework/controller/auth/AuthController.java
@@ -1,4 +1,4 @@
-package ru.skypro.homework.controller;
+package ru.skypro.homework.controller.auth;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,8 +8,8 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import ru.skypro.homework.dto.Login;
-import ru.skypro.homework.dto.Register;
+import ru.skypro.homework.dto.auth.Login;
+import ru.skypro.homework.dto.auth.Register;
 import ru.skypro.homework.service.AuthService;
 
 @Slf4j

--- a/src/main/java/ru/skypro/homework/controller/comment/CommentController.java
+++ b/src/main/java/ru/skypro/homework/controller/comment/CommentController.java
@@ -1,0 +1,39 @@
+package ru.skypro.homework.controller.comment;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import ru.skypro.homework.dto.comment.Comment;
+import ru.skypro.homework.dto.comment.Comments;
+import ru.skypro.homework.dto.comment.CreateOrUpdateComment;
+
+import java.util.Collections;
+
+@RestController
+@RequestMapping("/ads/{adId}/comments")
+@RequiredArgsConstructor
+@Tag(name = "Комментарии")
+public class CommentController {
+
+    @GetMapping
+    @Operation(summary = "Получение комментариев")
+    public Comments getComments(@PathVariable Integer adId) {
+        Comments stub = new Comments();
+        stub.setCount(0);
+        stub.setResults(Collections.emptyList());
+        return stub;
+    }
+
+    @PostMapping
+    @Operation(summary = "Добавление комментария")
+    public Comment addComment(
+            @PathVariable Integer adId,
+            @RequestBody CreateOrUpdateComment comment
+    ) {
+        Comment stub = new Comment();
+        stub.setPk(1);
+        stub.setText(comment.getText());
+        return stub;
+    }
+}

--- a/src/main/java/ru/skypro/homework/controller/image/ImageController.java
+++ b/src/main/java/ru/skypro/homework/controller/image/ImageController.java
@@ -1,0 +1,22 @@
+package ru.skypro.homework.controller.image;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ImageController {
+
+    @GetMapping("/storage/user_images/{filename}")
+    public ResponseEntity<byte[]> getUserImage(@PathVariable String filename) {
+        // Заглушка: возвращаем тестовую картинку
+        byte[] stubImage = new byte[10]; // Миниатюрная заглушка
+        return ResponseEntity.ok()
+                .contentType(MediaType.IMAGE_JPEG)
+                .body(stubImage);
+    }
+}

--- a/src/main/java/ru/skypro/homework/controller/user/UserController.java
+++ b/src/main/java/ru/skypro/homework/controller/user/UserController.java
@@ -1,0 +1,40 @@
+package ru.skypro.homework.controller.user;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import ru.skypro.homework.dto.user.UpdateUser;
+import ru.skypro.homework.dto.user.User;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+@Tag(name = "Пользователи")
+public class UserController {
+
+    @GetMapping("/me")
+    @Operation(summary = "Получение данных пользователя (заглушка)",
+            description = "Возвращает тестовые данные пользователя")
+    public ResponseEntity<User> getCurrentUser() {
+        // Создаём и заполняем заглушку пользователя
+        User user = new User();
+        user.setId(1);
+        user.setEmail("test@example.com");
+        user.setFirstName("Тестовый");
+        user.setLastName("Пользователь");
+        user.setPhone("+79990001122");
+        user.setRole("USER");
+        user.setImage("/images/default-avatar.jpg");
+
+        return ResponseEntity.ok(user);
+    }
+
+    @PatchMapping("/me")
+    @Operation(summary = "Обновление данных")
+    public UpdateUser updateUser(@RequestBody UpdateUser updateUser) {
+        // Заглушка: просто возвращаем то, что получили
+        return updateUser;
+    }
+}

--- a/src/main/java/ru/skypro/homework/dto/ad/Ad.java
+++ b/src/main/java/ru/skypro/homework/dto/ad/Ad.java
@@ -1,0 +1,14 @@
+package ru.skypro.homework.dto.ad;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "Краткая информация об объявлении")
+public class Ad {
+    private Integer author;
+    private String image;
+    private Integer pk;
+    private Integer price;
+    private String title;
+}

--- a/src/main/java/ru/skypro/homework/dto/ad/Ads.java
+++ b/src/main/java/ru/skypro/homework/dto/ad/Ads.java
@@ -1,0 +1,13 @@
+package ru.skypro.homework.dto.ad;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Schema(description = "Список объявлений с пагинацией")
+public class Ads {
+    private Integer count;
+    private List<Ad> results;
+}

--- a/src/main/java/ru/skypro/homework/dto/ad/CreateOrUpdateAd.java
+++ b/src/main/java/ru/skypro/homework/dto/ad/CreateOrUpdateAd.java
@@ -1,0 +1,21 @@
+package ru.skypro.homework.dto.ad;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Size;
+
+@Data
+@Schema(description = "Данные для создания/обновления объявления")
+public class CreateOrUpdateAd {
+    @Size(min = 4, max = 32)
+    private String title;
+
+    @Min(0) @Max(10000000)
+    private Integer price;
+
+    @Size(min = 8, max = 64)
+    private String description;
+}

--- a/src/main/java/ru/skypro/homework/dto/ad/ExtendedAd.java
+++ b/src/main/java/ru/skypro/homework/dto/ad/ExtendedAd.java
@@ -1,0 +1,18 @@
+package ru.skypro.homework.dto.ad;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "Полная информация об объявлении")
+public class ExtendedAd {
+    private Integer pk;
+    private String authorFirstName;
+    private String authorLastName;
+    private String description;
+    private String email;
+    private String image;
+    private String phone;
+    private Integer price;
+    private String title;
+}

--- a/src/main/java/ru/skypro/homework/dto/auth/Login.java
+++ b/src/main/java/ru/skypro/homework/dto/auth/Login.java
@@ -1,4 +1,4 @@
-package ru.skypro.homework.dto;
+package ru.skypro.homework.dto.auth;
 
 import lombok.Data;
 

--- a/src/main/java/ru/skypro/homework/dto/auth/Register.java
+++ b/src/main/java/ru/skypro/homework/dto/auth/Register.java
@@ -1,4 +1,4 @@
-package ru.skypro.homework.dto;
+package ru.skypro.homework.dto.auth;
 
 import lombok.Data;
 

--- a/src/main/java/ru/skypro/homework/dto/auth/Role.java
+++ b/src/main/java/ru/skypro/homework/dto/auth/Role.java
@@ -1,4 +1,4 @@
-package ru.skypro.homework.dto;
+package ru.skypro.homework.dto.auth;
 
 public enum Role {
     USER, ADMIN

--- a/src/main/java/ru/skypro/homework/dto/comment/Comment.java
+++ b/src/main/java/ru/skypro/homework/dto/comment/Comment.java
@@ -1,0 +1,15 @@
+package ru.skypro.homework.dto.comment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "Комментарий к объявлению")
+public class Comment {
+    private Integer author;
+    private String authorImage;
+    private String authorFirstName;
+    private Long createdAt;
+    private Integer pk;
+    private String text;
+}

--- a/src/main/java/ru/skypro/homework/dto/comment/Comments.java
+++ b/src/main/java/ru/skypro/homework/dto/comment/Comments.java
@@ -1,0 +1,13 @@
+package ru.skypro.homework.dto.comment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Schema(description = "Список комментариев с пагинацией")
+public class Comments {
+    private Integer count;
+    private List<Comment> results;
+}

--- a/src/main/java/ru/skypro/homework/dto/comment/CreateOrUpdateComment.java
+++ b/src/main/java/ru/skypro/homework/dto/comment/CreateOrUpdateComment.java
@@ -1,0 +1,15 @@
+package ru.skypro.homework.dto.comment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Data
+@Schema(description = "Данные для создания/обновления комментария")
+public class CreateOrUpdateComment {
+    @NotBlank
+    @Size(min = 8, max = 64)
+    private String text;
+}

--- a/src/main/java/ru/skypro/homework/dto/image/Image.java
+++ b/src/main/java/ru/skypro/homework/dto/image/Image.java
@@ -1,0 +1,9 @@
+package ru.skypro.homework.dto.image;
+
+import lombok.Data;
+
+@Data
+public class Image {
+    private byte[] imageBytes;
+    private String contentType;
+}

--- a/src/main/java/ru/skypro/homework/dto/user/NewPassword.java
+++ b/src/main/java/ru/skypro/homework/dto/user/NewPassword.java
@@ -1,0 +1,9 @@
+package ru.skypro.homework.dto.user;
+
+import lombok.Data;
+
+@Data
+public class NewPassword {
+    private String currentPassword;
+    private String newPassword;
+}

--- a/src/main/java/ru/skypro/homework/dto/user/UpdateUser.java
+++ b/src/main/java/ru/skypro/homework/dto/user/UpdateUser.java
@@ -1,0 +1,10 @@
+package ru.skypro.homework.dto.user;
+
+import lombok.Data;
+
+@Data
+public class UpdateUser {
+    private String firstName;
+    private String lastName;
+    private String phone;
+}

--- a/src/main/java/ru/skypro/homework/dto/user/User.java
+++ b/src/main/java/ru/skypro/homework/dto/user/User.java
@@ -1,0 +1,20 @@
+package ru.skypro.homework.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "DTO пользователя")
+public class User {
+    @Schema(description = "ID пользователя")
+    private Integer id;
+
+    @Schema(description = "Email (логин) пользователя")
+    private String email;
+
+    private String firstName;
+    private String lastName;
+    private String phone;
+    private String role;
+    private String image;
+}

--- a/src/main/java/ru/skypro/homework/service/AuthService.java
+++ b/src/main/java/ru/skypro/homework/service/AuthService.java
@@ -1,6 +1,6 @@
 package ru.skypro.homework.service;
 
-import ru.skypro.homework.dto.Register;
+import ru.skypro.homework.dto.auth.Register;
 
 public interface AuthService {
     boolean login(String userName, String password);

--- a/src/main/java/ru/skypro/homework/service/impl/AuthServiceImpl.java
+++ b/src/main/java/ru/skypro/homework/service/impl/AuthServiceImpl.java
@@ -5,7 +5,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.stereotype.Service;
-import ru.skypro.homework.dto.Register;
+import ru.skypro.homework.dto.auth.Register;
 import ru.skypro.homework.service.AuthService;
 
 @Service


### PR DESCRIPTION
Добавлены основные пакеты и классы для DTO и controller с "заглушками" в отсутствие бизнес логики, исходя из файла openapi.yaml:
- аутентификация;
- для объявлений;
- для комментариев;
- для пользователя;
- для изображений.